### PR TITLE
use window-relative font-size

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,4 @@
 html {
-  font-size: 62.5%;
   font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
 }
 
@@ -15,17 +14,5 @@ body {
 }
 
 .title {
-  font-size: 5rem;
-}
-
-// media queries
-@media (max-width: 28rem) {
-  .title {
-    font-size: 3rem;
-  }
-}
-@media (max-width: 17.5rem) {
-  .title {
-    font-size: 2rem;
-  }
+  font-size: 10vw;
 }


### PR DESCRIPTION
This *will* however make it larger on large screens, but will keep it always about the width of the screen. Alternatively you can use `vmin` to get the smallest metric (width or height)